### PR TITLE
Fixed mismatch between xpos and labels, probably a typo

### DIFF
--- a/distance.py
+++ b/distance.py
@@ -82,9 +82,11 @@ def plot_metric(to_plot,interval_colors,color,output_fname,metric_name,is_custom
     delta = 12
     if is_custom_labels:
         delta = 1
-    labels = [str(int(x)) if i%delta == 0 else '' for i,x in enumerate(xs2)]
-    
+
     xpos = np.arange(min(xs2), max(xs2)+1/delta, 1/delta)
+    labels = [str(int(x)) if i%delta == 0 else '' for i,x in enumerate(xpos)]
+    
+    
     plt.xticks(xpos,labels=labels,rotation=35)   
     
     if is_bg:


### PR DESCRIPTION
Na versão original um erro era gerado ao tentar gerar o arquivo shortest_path_2016_2019_psdb. Segue o traceback:

```
Traceback (most recent call last):
  File "distance.py", line 365, in <module>
    plot_shortest_paths_mandate(dates_by_mandate,nets_by_mandate,year,valid_pps,interval_colors,pps_color,False)
  File "distance.py", line 192, in plot_shortest_paths_mandate
    plot_shortest_paths(current_dates,current_nets,valid_pps,interval_colors,color,header,False,is_bg)
  File "distance.py", line 179, in plot_shortest_paths
    plot_metric(to_plot,interval_colors,color,header+pp1,'average shortest path len',is_custom_labels,is_bg)
  File "distance.py", line 88, in plot_metric
    plt.xticks(xpos,labels=labels,rotation=35)   
  File "/Users/pedroberaldo/opt/anaconda3/envs/political/lib/python3.8/site-packages/matplotlib/pyplot.py", line 1893, in xticks
    labels = ax.set_xticklabels(labels, minor=minor, **kwargs)
  File "/Users/pedroberaldo/opt/anaconda3/envs/political/lib/python3.8/site-packages/matplotlib/axes/_base.py", line 74, in wrapper
    return get_method(self)(*args, **kwargs)
  File "/Users/pedroberaldo/opt/anaconda3/envs/political/lib/python3.8/site-packages/matplotlib/_api/deprecation.py", line 297, in wrapper
    return func(*args, **kwargs)
  File "/Users/pedroberaldo/opt/anaconda3/envs/political/lib/python3.8/site-packages/matplotlib/axis.py", line 1969, in set_ticklabels
    raise ValueError(
ValueError: The number of FixedLocator locations (43), usually from a call to set_ticks, does not match the number of labels (41).
```

Antes o tanto _xpos_ quanto _labels_ eram gerados baseados no _xs2_. Agora apenas o _xpos_, garantindo que _xpos_ e _labels_ tenham sempre o mesmo tamanho.

Aproveitando o ensejo, agradeço pelo código! estou estudando uma proposta de mestrado e seu trabalho tem me ajudado muito!